### PR TITLE
Add static GitHub Pages version

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@
 
 - `frontend/` : GitHub Pages などの静的ホスティングで公開する HTML/JavaScript
 - `backend/`  : Flask による API サーバ
+- `static_pages/` : バックエンドを使用しない GitHub Pages 向けの純粋な HTML/CSS/JavaScript
 
 ## セットアップ
 
@@ -39,6 +40,13 @@ pytest
 - `/api/puzzles` でスタート記事とゴール記事のペアを取得します。
 - `/api/validate` にユーザーが入力した経路を送信すると、各ステップでリンクが存在するか MediaWiki API を通じて確認します。
 - 正当であればステップ数を返し、そうでなければ失敗したステップ番号を返します。
+
+## GitHub Pages 静的版
+
+`static_pages/` ディレクトリには、バックエンドを使用せず Wikipedia API だけで動作
+する簡易版を用意しています。GitHub Pages へそのまま配置することで動作確認できます。
+`puzzles.json` にスタートとゴールの記事を定義しており、ブラウザのみで検証を行いま
+す。
 
 ## 免責
 

--- a/static_pages/index.html
+++ b/static_pages/index.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<html lang="ja">
+<head>
+    <meta charset="UTF-8">
+    <title>Wikipedia Race</title>
+    <style>
+        body { font-family: sans-serif; margin: 2em; }
+        .invalid { border-color: red; }
+    </style>
+</head>
+<body>
+<h1>Wikipedia Race</h1>
+<div id="puzzle-info"></div>
+<div id="form-container"></div>
+<button id="add-step">＋</button>
+<button id="validate">検証</button>
+<div id="result"></div>
+<script src="main.js"></script>
+</body>
+</html>

--- a/static_pages/main.js
+++ b/static_pages/main.js
@@ -1,0 +1,83 @@
+const formContainer = document.getElementById('form-container');
+const addStepBtn = document.getElementById('add-step');
+const validateBtn = document.getElementById('validate');
+const resultDiv = document.getElementById('result');
+let currentPuzzle = null;
+
+function createInput() {
+    const input = document.createElement('input');
+    input.type = 'text';
+    input.placeholder = 'https://ja.wikipedia.org/wiki/記事';
+    input.addEventListener('input', () => {
+        const re = /^https:\/\/ja\.wikipedia\.org\/wiki\/.+/;
+        if (re.test(input.value)) {
+            input.classList.remove('invalid');
+        } else {
+            input.classList.add('invalid');
+        }
+    });
+    formContainer.appendChild(input);
+}
+
+addStepBtn.addEventListener('click', () => {
+    createInput();
+});
+
+async function loadPuzzle() {
+    const resp = await fetch('puzzles.json');
+    const data = await resp.json();
+    currentPuzzle = data.puzzles[0];
+    const info = document.getElementById('puzzle-info');
+    info.textContent = `Start: ${currentPuzzle.start_title} → Goal: ${currentPuzzle.goal_title}`;
+}
+
+async function checkLinkExists(sourceTitle, targetTitle) {
+    const params = new URLSearchParams({
+        action: 'query',
+        prop: 'links',
+        titles: sourceTitle,
+        pllimit: 'max',
+        format: 'json',
+        origin: '*'
+    });
+    const url = `https://ja.wikipedia.org/w/api.php?${params.toString()}`;
+    const resp = await fetch(url);
+    const data = await resp.json();
+    const pages = data.query && data.query.pages ? data.query.pages : {};
+    for (const key in pages) {
+        const links = pages[key].links || [];
+        if (links.some(l => l.title === targetTitle)) {
+            return true;
+        }
+    }
+    return false;
+}
+
+validateBtn.addEventListener('click', async () => {
+    if (!currentPuzzle) return;
+    const inputs = Array.from(formContainer.querySelectorAll('input'));
+    const titles = inputs.map(inp => inp.value.match(/wiki\/(.+)/)?.[1] || '');
+    if (titles.some(t => !t)) {
+        resultDiv.textContent = 'URLを確認してください';
+        return;
+    }
+    const route = [currentPuzzle.start_title, ...titles, currentPuzzle.goal_title];
+    for (let i = 0; i < route.length - 1; i++) {
+        try {
+            const ok = await checkLinkExists(route[i], route[i + 1]);
+            if (!ok) {
+                resultDiv.textContent = `失敗: ステップ${i + 1}でリンクが見つかりません`;
+                const targetInput = inputs[i];
+                if (targetInput) targetInput.classList.add('invalid');
+                return;
+            }
+        } catch (e) {
+            resultDiv.textContent = '通信エラー';
+            return;
+        }
+    }
+    resultDiv.textContent = `成功! ステップ数: ${route.length - 1}`;
+});
+
+loadPuzzle();
+createInput();

--- a/static_pages/puzzles.json
+++ b/static_pages/puzzles.json
@@ -1,0 +1,1 @@
+{"puzzles": [{"puzzle_id": 1, "start_title": "HTTP", "goal_title": "UNIX"}]}


### PR DESCRIPTION
## Summary
- create `static_pages` folder with pure HTML/CSS/JS version
- use Wikipedia API directly from browser via `main.js`
- include `puzzles.json` with start and goal article
- document new folder and usage in README

## Testing
- `pytest -q`