### PR TITLE
フロントエンドを返すルート追加

### DIFF
--- a/backend/app.py
+++ b/backend/app.py
@@ -4,9 +4,11 @@ import time
 import random
 from datetime import datetime
 
-from flask import Flask, request, jsonify
+from flask import Flask, request, jsonify, send_from_directory
+import os
 import requests
 
+# フロントエンドのHTMLを提供するためstatic_folderを指定
 app = Flask(__name__)
 
 DB_PATH = 'wikirace.db'
@@ -134,6 +136,13 @@ def check_link_exists(source_title, target_title, retries=3):
             attempt += 1
 
     raise RuntimeError('API unreachable')
+
+
+@app.route('/')
+def index():
+    """フロントエンドのHTMLを返すシンプルなルート"""
+    frontend_dir = os.path.join(os.path.dirname(__file__), '..', 'frontend')
+    return send_from_directory(frontend_dir, 'index.html')
 
 
 @app.route('/api/puzzles', methods=['GET'])

--- a/tests/test_root_route.py
+++ b/tests/test_root_route.py
@@ -1,0 +1,14 @@
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "backend"))
+
+import pytest
+app = pytest.importorskip("app")
+
+
+def test_root_returns_index_html():
+    client = app.app.test_client()
+    resp = client.get("/")
+    assert resp.status_code == 200
+    assert b"Wikipedia Race" in resp.data


### PR DESCRIPTION
## 概要
- ルート `/` へアクセスした際にフロントエンドの `index.html` を返すよう `backend/app.py` を修正しました
- これに伴い簡単なテスト `tests/test_root_route.py` を追加しました

## テスト結果
- `pytest` 実行結果（一部依存関係未インストールのため二つのテストは skip）
