### PR TITLE
フロントエンド改善: 入力欄縦並びと削除機能追加

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -5,7 +5,11 @@
   <title>Wikipedia Race</title>
   <style>
     body { font-family: sans-serif; margin: 2em; }
+    #form-container { display: flex; flex-direction: column; gap: 0.5em; }
+    .input-row { display: flex; align-items: center; gap: 0.5em; }
+    input { flex: 1; padding: 0.4em; border-radius: 4px; border: 1px solid #ccc; }
     .invalid { border: 2px solid red; }
+    button { padding: 0.4em 0.8em; border-radius: 4px; border: 1px solid #888; background: #eee; }
   </style>
 </head>
 <body>
@@ -37,14 +41,26 @@
      入力フィールド生成
   ───────────────────────────── */
   function createInput() {
+    // 入力欄と削除ボタンをまとめるラッパー
+    const row = document.createElement('div');
+    row.className = 'input-row';
+
     const input = document.createElement('input');
     input.type = 'text';
     input.placeholder = 'https://ja.wikipedia.org/wiki/記事';
+    // 入力検証
     input.addEventListener('input', () => {
       const ok = /^https:\/\/ja\.wikipedia\.org\/wiki\/[^#?]+/.test(input.value);
       input.classList.toggle('invalid', !ok);
     });
-    formContainer.appendChild(input);
+
+    const removeBtn = document.createElement('button');
+    removeBtn.textContent = '－';
+    removeBtn.addEventListener('click', () => row.remove());
+
+    row.appendChild(input);
+    row.appendChild(removeBtn);
+    formContainer.appendChild(row);
   }
 
   addStepBtn.addEventListener('click', createInput);

--- a/static_pages/index.html
+++ b/static_pages/index.html
@@ -5,7 +5,11 @@
     <title>Wikipedia Race</title>
     <style>
         body { font-family: sans-serif; margin: 2em; }
+        #form-container { display: flex; flex-direction: column; gap: 0.5em; }
+        .input-row { display: flex; align-items: center; gap: 0.5em; }
+        input { flex: 1; padding: 0.4em; border-radius: 4px; border: 1px solid #ccc; }
         .invalid { border-color: red; }
+        button { padding: 0.4em 0.8em; border-radius: 4px; border: 1px solid #888; background: #eee; }
     </style>
 </head>
 <body>

--- a/static_pages/main.js
+++ b/static_pages/main.js
@@ -5,6 +5,10 @@ const resultDiv = document.getElementById('result');
 let currentPuzzle = null;
 
 function createInput() {
+    // 入力欄と削除ボタンを持つ行要素
+    const row = document.createElement('div');
+    row.className = 'input-row';
+
     const input = document.createElement('input');
     input.type = 'text';
     input.placeholder = 'https://ja.wikipedia.org/wiki/記事';
@@ -16,7 +20,14 @@ function createInput() {
             input.classList.add('invalid');
         }
     });
-    formContainer.appendChild(input);
+
+    const removeBtn = document.createElement('button');
+    removeBtn.textContent = '－';
+    removeBtn.addEventListener('click', () => row.remove());
+
+    row.appendChild(input);
+    row.appendChild(removeBtn);
+    formContainer.appendChild(row);
 }
 
 addStepBtn.addEventListener('click', () => {


### PR DESCRIPTION
## 概要
- 入力欄を横並びから縦並びに変更し、スタイルを調整
- 各入力欄に削除ボタンを追加
- `static_pages` 側も同様に更新
- 既存テストに影響がないことを確認

## テスト結果
- `pytest -q` 実行済みで全テスト成功
