### PR TITLE
フロントエンド改善とパズル登録API追加

### DIFF
--- a/backend/services/database.py
+++ b/backend/services/database.py
@@ -31,3 +31,17 @@ def save_submission(puzzle_id: int, user_name: str, path, step_count: int) -> No
 def get_ranking(puzzle_id: int):
     """ランキング情報を取得"""
     return Submission.ranking(puzzle_id)
+
+
+def add_puzzle(start_title: str, goal_title: str) -> Puzzle:
+    """新しいパズルを追加"""
+    now = datetime.utcnow()
+    puzzle = Puzzle(
+        puzzle_id=None,
+        start_title=start_title,
+        goal_title=goal_title,
+        created_at=now,
+        updated_at=now,
+    )
+    puzzle.save()
+    return puzzle

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -3,151 +3,22 @@
 <head>
   <meta charset="UTF-8">
   <title>Wikipedia Race</title>
-  <style>
-    body { font-family: sans-serif; margin: 2em; }
-    #form-container { display: flex; flex-direction: column; gap: 0.5em; }
-    .input-row { display: flex; align-items: center; gap: 0.5em; }
-    input { flex: 1; padding: 0.4em; border-radius: 4px; border: 1px solid #ccc; }
-    .invalid { border: 2px solid red; }
-    button { padding: 0.4em 0.8em; border-radius: 4px; border: 1px solid #888; background: #eee; }
-  </style>
+  <link rel="stylesheet" href="/static/style.css">
+  <script src="/static/main.js" defer></script>
 </head>
 <body>
   <h1>Wikipedia Race</h1>
-
-  <div id="puzzle-info"></div>
+  <div id="puzzle-section">
+    <select id="puzzle-select"></select>
+    <div id="puzzle-info"></div>
+  </div>
   <div id="form-container"></div>
-  <button id="add-step">＋</button>
-  <button id="validate">検証</button>
+  <div class="buttons">
+    <button id="add-step">＋</button>
+    <button id="validate">検証</button>
+  </div>
   <div id="result"></div>
-
-  <script>
-  /* ─────────────────────────────
-     デバッグユーティリティ
-  ───────────────────────────── */
-  const DEBUG = true;          // false にすると静かになる
-  const log   = (...a) => DEBUG && console.log('[DEBUG]', ...a);
-
-  /* ─────────────────────────────
-     DOM 要素
-  ───────────────────────────── */
-  const formContainer = document.getElementById('form-container');
-  const addStepBtn    = document.getElementById('add-step');
-  const validateBtn   = document.getElementById('validate');
-  const resultDiv     = document.getElementById('result');
-  let   currentPuzzle = null;
-
-  /* ─────────────────────────────
-     入力フィールド生成
-  ───────────────────────────── */
-  function createInput() {
-    // 入力欄と削除ボタンをまとめるラッパー
-    const row = document.createElement('div');
-    row.className = 'input-row';
-
-    const input = document.createElement('input');
-    input.type = 'text';
-    input.placeholder = 'https://ja.wikipedia.org/wiki/記事';
-    // 入力検証
-    input.addEventListener('input', () => {
-      const ok = /^https:\/\/ja\.wikipedia\.org\/wiki\/[^#?]+/.test(input.value);
-      input.classList.toggle('invalid', !ok);
-    });
-
-    const removeBtn = document.createElement('button');
-    removeBtn.textContent = '－';
-    removeBtn.addEventListener('click', () => row.remove());
-
-    row.appendChild(input);
-    row.appendChild(removeBtn);
-    formContainer.appendChild(row);
-  }
-
-  addStepBtn.addEventListener('click', createInput);
-
-  /* ─────────────────────────────
-     パズル取得
-  ───────────────────────────── */
-  function fetchPuzzle() {
-    fetch('/api/puzzles')
-      .then(r => r.json())
-      .then(data => {
-        log('Puzzle list', data);
-        currentPuzzle = data.puzzles[0];
-        document.getElementById('puzzle-info').textContent =
-          `Start: ${currentPuzzle.start_title} → Goal: ${currentPuzzle.goal_title}`;
-      })
-      .catch(err => console.error('Puzzle fetch error', err));
-  }
-
-  /* ─────────────────────────────
-     URL→タイトル変換
-  ───────────────────────────── */
-  function extractTitleFromUrl(url) {
-    const m = url.match(/^https:\/\/ja\.wikipedia\.org\/wiki\/([^#?]+)/);
-    if (!m) return '';
-    let title = decodeURIComponent(m[1]).replace(/_/g, ' ');
-    title = title.charAt(0).toUpperCase() + title.slice(1);
-    return title.trim();
-  }
-
-  /* ─────────────────────────────
-     検証ボタン押下
-  ───────────────────────────── */
-  validateBtn.addEventListener('click', () => {
-    if (!currentPuzzle) return;
-
-    const inputs = Array.from(formContainer.querySelectorAll('input'));
-    const titles = inputs.map(inp => extractTitleFromUrl(inp.value));
-
-    if (titles.some(t => !t)) {
-      resultDiv.textContent = 'URLを確認してください';
-      return;
-    }
-
-    const route = [
-      currentPuzzle.start_title,
-      ...titles,
-      currentPuzzle.goal_title
-    ];
-
-    log('Sending route', route);
-
-    fetch('/api/validate', {
-      method : 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body   : JSON.stringify({
-        puzzle_id: currentPuzzle.puzzle_id,
-        route    : route
-      })
-    })
-    .then(r => r.json())
-    .then(data => {
-      log('Validate response', data);
-
-      if (data.valid) {
-        resultDiv.textContent = `成功! ステップ数: ${data.step_count}`;
-      } else if (data.failed_step) {
-        resultDiv.textContent = `失敗: ステップ${data.failed_step}でリンクが見つかりません`;
-        const bad = inputs[data.failed_step - 1];
-        if (bad) bad.classList.add('invalid');
-      } else if (data.error) {
-        resultDiv.textContent = `エラー: ${data.error}`;
-      } else {
-        resultDiv.textContent = '未知のエラー';
-      }
-    })
-    .catch(err => {
-      console.error('Fetch error', err);
-      resultDiv.textContent = '通信エラー';
-    });
-  });
-
-  /* ─────────────────────────────
-     初期化
-  ───────────────────────────── */
-  fetchPuzzle();
-  createInput();         // 1 本目の入力欄
-  </script>
+  <h2>ランキング</h2>
+  <ol id="ranking"></ol>
 </body>
 </html>

--- a/frontend/main.js
+++ b/frontend/main.js
@@ -1,0 +1,132 @@
+const DEBUG = true;
+const log = (...a) => DEBUG && console.log('[DEBUG]', ...a);
+const puzzleSelect  = document.getElementById('puzzle-select');
+const puzzleInfo    = document.getElementById('puzzle-info');
+const formContainer = document.getElementById('form-container');
+const addStepBtn    = document.getElementById('add-step');
+const validateBtn   = document.getElementById('validate');
+const resultDiv     = document.getElementById('result');
+const rankingList   = document.getElementById('ranking');
+let currentPuzzle   = null;
+
+function createInput() {
+  const row = document.createElement('div');
+  row.className = 'input-row';
+  const input = document.createElement('input');
+  input.type = 'text';
+  input.placeholder = 'https://ja.wikipedia.org/wiki/記事';
+  input.addEventListener('input', () => {
+    const ok = /^https:\/\/ja\.wikipedia\.org\/wiki\/[^#?]+/.test(input.value);
+    input.classList.toggle('invalid', !ok);
+  });
+  const remove = document.createElement('button');
+  remove.textContent = '－';
+  remove.addEventListener('click', () => row.remove());
+  row.appendChild(input);
+  row.appendChild(remove);
+  formContainer.appendChild(row);
+}
+
+function resetInputs() {
+  formContainer.innerHTML = '';
+  createInput();
+}
+
+addStepBtn.addEventListener('click', createInput);
+
+function extractTitleFromUrl(url) {
+  const m = url.match(/^https:\/\/ja\.wikipedia\.org\/wiki\/([^#?]+)/);
+  if (!m) return '';
+  let title = decodeURIComponent(m[1]).replace(/_/g, ' ');
+  title = title.charAt(0).toUpperCase() + title.slice(1);
+  return title.trim();
+}
+
+function updatePuzzleInfo() {
+  if (!currentPuzzle) return;
+  puzzleInfo.textContent = `Start: ${currentPuzzle.start_title} → Goal: ${currentPuzzle.goal_title}`;
+}
+
+function loadPuzzles() {
+  fetch('/api/puzzles')
+    .then(r => r.json())
+    .then(data => {
+      puzzleSelect.innerHTML = '';
+      data.puzzles.forEach(p => {
+        const opt = document.createElement('option');
+        opt.value = p.puzzle_id;
+        opt.textContent = `${p.start_title} → ${p.goal_title}`;
+        puzzleSelect.appendChild(opt);
+      });
+      currentPuzzle = data.puzzles[0];
+      puzzleSelect.value = currentPuzzle.puzzle_id;
+      updatePuzzleInfo();
+      fetchRanking();
+    })
+    .catch(err => console.error('Puzzle fetch error', err));
+}
+
+puzzleSelect.addEventListener('change', () => {
+  const id = Number(puzzleSelect.value);
+  fetch('/api/puzzles')
+    .then(r => r.json())
+    .then(data => {
+      currentPuzzle = data.puzzles.find(p => p.puzzle_id === id);
+      updatePuzzleInfo();
+      resetInputs();
+      fetchRanking();
+    });
+});
+
+function fetchRanking() {
+  rankingList.innerHTML = '';
+  if (!currentPuzzle) return;
+  fetch(`/api/ranking?puzzle_id=${currentPuzzle.puzzle_id}`)
+    .then(r => r.json())
+    .then(data => {
+      (data.ranking || []).forEach(row => {
+        const li = document.createElement('li');
+        li.textContent = `${row.user_name}: ${row.step_count} steps`;
+        rankingList.appendChild(li);
+      });
+    })
+    .catch(err => console.error('Ranking error', err));
+}
+
+validateBtn.addEventListener('click', () => {
+  if (!currentPuzzle) return;
+  const inputs = Array.from(formContainer.querySelectorAll('input'));
+  const titles = inputs.map(inp => extractTitleFromUrl(inp.value));
+  if (titles.some(t => !t)) {
+    resultDiv.textContent = 'URLを確認してください';
+    return;
+  }
+  const route = [currentPuzzle.start_title, ...titles, currentPuzzle.goal_title];
+  fetch('/api/validate', {
+    method: 'POST',
+    headers: {'Content-Type': 'application/json'},
+    body: JSON.stringify({puzzle_id: currentPuzzle.puzzle_id, route})
+  })
+    .then(r => r.json())
+    .then(data => {
+      if (data.valid) {
+        resultDiv.textContent = `成功! ステップ数: ${data.step_count}`;
+        fetchRanking();
+      } else if (data.failed_step) {
+        resultDiv.textContent = `失敗: ステップ${data.failed_step}でリンクが見つかりません`;
+        const bad = inputs[data.failed_step - 1];
+        if (bad) bad.classList.add('invalid');
+      } else if (data.error) {
+        resultDiv.textContent = `エラー: ${data.error}`;
+      } else {
+        resultDiv.textContent = '未知のエラー';
+      }
+    })
+    .catch(err => {
+      console.error('Fetch error', err);
+      resultDiv.textContent = '通信エラー';
+    });
+});
+
+loadPuzzles();
+resetInputs();

--- a/frontend/style.css
+++ b/frontend/style.css
@@ -1,0 +1,38 @@
+body {
+  font-family: sans-serif;
+  margin: 2em auto;
+  max-width: 800px;
+}
+#puzzle-info {
+  margin: 0.5em 0;
+  font-weight: bold;
+}
+.input-row {
+  display: flex;
+  align-items: center;
+  gap: 0.5em;
+  margin-bottom: 0.5em;
+}
+input[type="text"] {
+  flex: 1;
+  padding: 0.4em;
+  border-radius: 4px;
+  border: 1px solid #ccc;
+}
+.invalid {
+  border: 2px solid red;
+}
+.buttons {
+  display: flex;
+  gap: 0.5em;
+  margin-bottom: 1em;
+}
+button {
+  padding: 0.4em 0.8em;
+  border-radius: 4px;
+  border: 1px solid #888;
+  background: #eee;
+}
+#ranking {
+  padding-left: 1.2em;
+}

--- a/tests/test_add_puzzle.py
+++ b/tests/test_add_puzzle.py
@@ -1,0 +1,29 @@
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "backend"))
+
+import pytest
+
+pytest.importorskip("flask")
+pytest.importorskip("sqlalchemy")
+
+import app  # type: ignore
+from routes.api import ADMIN_TOKEN
+
+
+def test_add_puzzle_requires_token():
+    client = app.app.test_client()
+    resp = client.post("/api/puzzles", json={"start_title": "A", "goal_title": "B"})
+    assert resp.status_code == 401
+
+
+def test_add_puzzle_success():
+    client = app.app.test_client()
+    resp = client.post(
+        "/api/puzzles",
+        json={"start_title": "A", "goal_title": "B"},
+        headers={"Authorization": f"Bearer {ADMIN_TOKEN}"},
+    )
+    assert resp.status_code == 201
+    assert "puzzle_id" in resp.get_json()


### PR DESCRIPTION
## 概要
- フロントエンドのJS/CSSを分離してUIを強化
- 管理者のみ利用できるパズル追加APIを実装
- `/static/` 経由で静的ファイルを提供
- 新API向けのテストを追加（依存ライブラリ未インストール時はskip）

## テスト結果
- `pytest` 実行で既存テストが成功し、新規テストは依存不足のため skip されることを確認


------
https://chatgpt.com/codex/tasks/task_b_6851432b7acc83268dc246dedaf8bdaf